### PR TITLE
Fix eventlet compatibility with Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==2.3.3
 Flask-SocketIO==5.3.4
 python-socketio==5.9.0
 PyYAML==6.0.1
-eventlet==0.33.3
+eventlet==0.36.1


### PR DESCRIPTION
## Summary
- Updates eventlet from 0.33.3 to 0.36.1 to fix Python 3.12 compatibility
- Resolves AttributeError: module 'ssl' has no attribute 'wrap_socket'

## Test plan
- [ ] Install updated dependencies with `pip install -r requirements.txt --upgrade`
- [ ] Run the application with `python app.py`
- [ ] Verify the application starts without the ssl.wrap_socket error
- [ ] Test basic functionality: log file loading and regex pattern matching

🤖 Generated with [Claude Code](https://claude.ai/code)