### PR TITLE
Fix Claude Code action reference

### DIFF
--- a/.github/claude-code-review.md
+++ b/.github/claude-code-review.md
@@ -1,6 +1,6 @@
 # Claude Code Review Configuration
 
-This repository uses Claude Code for automated PR reviews to maintain code quality and catch potential issues early.
+This repository uses Claude Code for automated PR reviews and code assistance via GitHub Actions.
 
 ## Setup
 
@@ -10,37 +10,49 @@ Add the following secrets to your GitHub repository settings:
 
 1. `ANTHROPIC_API_KEY` - Your Anthropic API key for Claude access
 
-### Configuration
+### How It Works
 
-The Claude Code review is configured to focus on:
+The Claude Code action responds to:
+- **Pull Requests** - Automatically triggers on PR creation and updates
+- **@claude mentions** - Comment "@claude" in any PR or Issue to get help
 
-- **Security vulnerabilities** - Identifying potential security issues
-- **Performance issues** - Spotting performance bottlenecks
-- **Code quality and best practices** - Ensuring clean, maintainable code
-- **Python-specific improvements** - Python idioms and best practices
-- **Flask/SocketIO specific concerns** - Framework-specific issues
+### Usage Examples
 
-### Excluded Files
+**Request a code review:**
+```
+@claude please review this PR for security issues and performance problems
+```
 
-The following files/directories are excluded from review:
-- `venv/` - Virtual environment
-- `uploads/` - Upload directory
-- `*.png` - Image files
-- `*.log` - Log files
+**Ask for help with implementation:**
+```
+@claude can you help implement error handling for the file upload feature?
+```
+
+**General questions:**
+```
+@claude explain how the regex pattern matching works in this code
+```
+
+## Configuration
+
+The workflow is configured with:
+- **Model**: Claude 3.5 Sonnet for high-quality analysis
+- **Trigger**: "@claude" mentions in comments
+- **Permissions**: Read code, write to PRs and issues
+- **Environment**: Python 3.12 with project dependencies
 
 ## Customization
 
-To modify the review configuration, edit `.github/workflows/claude-code-review.yml`:
+To modify the configuration, edit `.github/workflows/claude-code-review.yml`:
 
-- Change `review-level` to `basic` or `comprehensive`
-- Modify `focus-areas` to add or remove review criteria
-- Update `exclude-files` to change which files are ignored
-- Adjust the `model` if you want to use a different Claude model
+- Change `model` to use a different Claude model
+- Modify `trigger_phrase` to use a different activation phrase
+- Add additional workflow steps for specific project needs
 
 ## Manual Reviews
 
-You can also request manual Claude Code reviews by:
+You can also use Claude Code directly:
 
-1. Installing Claude Code CLI: `pip install claude-code`
-2. Running: `claude-code review <file-or-directory>`
-3. Or using the web interface at [claude.ai/code](https://claude.ai/code)
+1. Install Claude Code CLI: Follow instructions at [claude.ai/code](https://claude.ai/code)
+2. Run terminal commands: `claude-code review <file>`
+3. Use VS Code or JetBrains extensions for IDE integration

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,8 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
 
 jobs:
   claude-review:
@@ -29,22 +31,11 @@ jobs:
           pip install -r requirements.txt
       
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-review-action@v1
+        uses: anthropics/claude-code-action@beta
         with:
-          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           model: claude-3-5-sonnet-20241022
-          review-level: detailed
-          focus-areas: |
-            - Security vulnerabilities
-            - Performance issues
-            - Code quality and best practices
-            - Python-specific improvements
-            - Flask/SocketIO specific concerns
-          exclude-files: |
-            - venv/
-            - uploads/
-            - *.png
-            - *.log
+          trigger_phrase: "@claude"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fixes the GitHub Actions workflow to use the correct `anthropics/claude-code-action@beta` instead of the non-existent `claude-code-review-action@v1`
- Updates parameter names to match the actual action API

## Changes
- ✅ Change action from `claude-code-review-action@v1` to `claude-code-action@beta`
- ✅ Add `issue_comment` trigger for @claude mentions in PR/issue comments  
- ✅ Fix parameter names (`anthropic_api_key` vs `anthropic-api-key`)
- ✅ Update documentation with correct usage examples
- ✅ Simplify configuration to use official action parameters

## Test plan
- [ ] Merge this PR
- [ ] Add `ANTHROPIC_API_KEY` secret to repository settings if not already added
- [ ] Create a test PR and comment "@claude please review this code"
- [ ] Verify the workflow runs without the "action not found" error
- [ ] Confirm Claude responds to the @claude mention

🤖 Generated with [Claude Code](https://claude.ai/code)