### PR TITLE
Update Claude model to resolve API error

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-3-5-sonnet-20241022
+          model: claude-4-0-sonnet-latest
           trigger_phrase: "@claude"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Updates the Claude model from `claude-3-5-sonnet-20241022` to `claude-4-0-sonnet-latest` to resolve the API error: "'claude-3-5-sonnet-20241022' does not support thinking."

## Changes
- ✅ Change model from `claude-3-5-sonnet-20241022` to `claude-4-0-sonnet-latest`
- ✅ Resolves the "does not support thinking" API error

## Why Claude 4?
- Claude 4 models have broader capability support
- Should resolve the thinking mode compatibility issue
- Latest model ensures best performance and features

## Test plan
- [ ] Merge this PR 
- [ ] Test the workflow by commenting "@claude please review this code" on a PR
- [ ] Verify no API errors occur
- [ ] Confirm Claude responds appropriately

🤖 Generated with [Claude Code](https://claude.ai/code)