### PR TITLE
Fix Claude model to use correct Sonnet 4 name

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,29 +13,29 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.12'
-      
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      
+
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-4-0-sonnet-latest
+          model: claude-sonnet-4-latest
           trigger_phrase: "@claude"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Updates the Claude model from `claude-4-0-sonnet-latest` to `claude-sonnet-4-latest` to use the correct model identifier.

## Changes
- ✅ Change model from `claude-4-0-sonnet-latest` to `claude-sonnet-4-latest`
- ✅ Use the correct Claude Sonnet 4 model naming convention

## Why This Fix?
The previous model name `claude-4-0-sonnet-latest` was returning a 404 error because it doesn't exist. The correct naming convention for Claude Sonnet 4 is `claude-sonnet-4-latest`.

## Test plan
- [ ] Merge this PR
- [ ] Test the workflow by commenting "@claude please review this code" on a PR
- [ ] Verify no 404 model errors occur
- [ ] Confirm Claude Sonnet 4 responds appropriately

🤖 Generated with [Claude Code](https://claude.ai/code)