### PR TITLE
Remove model parameter from Claude Code workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-sonnet-4-latest
           trigger_phrase: "@claude"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Removes the `model` parameter from the Claude Code GitHub Actions workflow to use the action's default model selection.

## Why This Change?
- Anthropic's model naming conventions are inconsistent
- Previous attempts with specific model names resulted in 404 errors
- The `model` parameter is optional in the claude-code-action
- Using defaults ensures compatibility and avoids naming issues

## Changes
- ✅ Remove `model: claude-sonnet-4-latest` parameter
- ✅ Let claude-code-action use its default model selection
- ✅ Simplify workflow configuration

## Benefits
- Eliminates model naming compatibility issues
- Reduces maintenance overhead
- Action will automatically use appropriate/available models
- Avoids future API errors from model name changes

## Test plan
- [ ] Merge this PR
- [ ] Test the workflow by commenting "@claude please review this code" on a PR
- [ ] Verify no model-related API errors occur
- [ ] Confirm Claude responds using the default model

🤖 Generated with [Claude Code](https://claude.ai/code)